### PR TITLE
column name and status change to prep for use of enum on booking status

### DIFF
--- a/db/migrate/20220126162159_change_confirmed_to_status_in_bookings.rb
+++ b/db/migrate/20220126162159_change_confirmed_to_status_in_bookings.rb
@@ -1,0 +1,9 @@
+class ChangeConfirmedToStatusInBookings < ActiveRecord::Migration[6.0]
+  
+  # change column name from confirmed to status
+  def change
+    rename_column :bookings, :confirmed, :status
+    # for booking status the enums will be "waiting", "confirmed", "declined", "completed"
+    change_column :bookings, :status, :string, null: false, default: 'waiting'
+  end
+end

--- a/db/migrate/20220126162159_change_confirmed_to_status_in_bookings.rb
+++ b/db/migrate/20220126162159_change_confirmed_to_status_in_bookings.rb
@@ -1,8 +1,9 @@
 class ChangeConfirmedToStatusInBookings < ActiveRecord::Migration[6.0]
-  
-  # change column name from confirmed to status
   def change
+    # change column name from `confirmed` to `status`
     rename_column :bookings, :confirmed, :status
+
+    # updating the status column's type
     # for booking status the enums will be "waiting", "confirmed", "declined", "completed"
     change_column :bookings, :status, :string, null: false, default: 'waiting'
   end


### PR DESCRIPTION
This migration will update the bookings table's `confirmed` column to `status`

bookings table should then look like this
```ruby
  create_table "bookings", force: :cascade do |t|
    t.bigint "user_id", null: false
    t.bigint "kondo_id", null: false
    t.string "status", default: "waiting", null: false
    t.datetime "booked_date"
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
    t.index ["kondo_id"], name: "index_bookings_on_kondo_id"
    t.index ["user_id"], name: "index_bookings_on_user_id"
  end
```