### PR TITLE
migration to add sercvice duration to kondo model

### DIFF
--- a/db/migrate/20220127115736_add_service_duration_to_kondo.rb
+++ b/db/migrate/20220127115736_add_service_duration_to_kondo.rb
@@ -1,0 +1,6 @@
+class AddServiceDurationToKondo < ActiveRecord::Migration[6.0]
+  def change
+    add_column :kondos, :service_duration, :integer, null: false
+  end
+end
+


### PR DESCRIPTION
When running this migration, we'll need to drop and re-create the db. Reason why is there may already be existing kondos and adding the serivce_duration column to those kondos is gonna make the column value null but I placed it as null: false.