### PR TITLE
fixed banner image disappearing on dev

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,0 +1,20 @@
+.home-banner {
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  background: -webkit-linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3));
+
+  img {
+    pointer-events: none;
+    object-fit: contain;
+    position: absolute;
+    min-width: 100%;
+    min-height: 100%;
+    z-index: -1;
+  }
+
+  h1 {
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -3,6 +3,8 @@
   position: relative;
   width: 100%;
   height: 100vh;
+  // next line was from: https://stackoverflow.com/a/23935891/6728463
+  // truth is we need more lines to make this work with other browsers but we don't care about it right now
   background: -webkit-linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3));
 
   img {

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,4 +4,5 @@
 @import "navbar";
 @import "card";
 @import "sidebar";
-@import "form"
+@import "form";
+@import "banner";

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,8 +1,10 @@
-<div class="card-category d-flex flex-column justify-content-center align-items-center" 
-style="height: 100vh; background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path ENV["HOME_BACKGROUND"], crop: :fill %>')">
+<div class="home-banner d-flex flex-column justify-content-center align-items-center">
+  <%# argument is the id of the img from cloudinary's development folder, does not matter if from dev or prod directory %>
+  <%= cl_image_tag("interior_ncfcmy_vjp2mu")%>
   <h1 id="banner-text">Make Your <span style="color:#FF773D">Home</span> a Better Place</h1>
   <%= render "components/searchBar" %>
 </div>
+
 <div class="container">
   <h2>Interior Specialists near you</h2>
     <div class="row justify-content-center">


### PR DESCRIPTION
**Note:** After this gets merged, no need to keep `HOME_BACKGROUND` from your `.env.` files anymore.


**What happened in this PR**
- Maintained the same banner looks as before, used cl_image_tag instead of cl_image_path.
- **cl_image_path** url changes on refresh causing our banner image to break. We should never ever use this ~~helper~~ headache ever again.