### PR TITLE
homepage fix on being able to scroll to the right past the gradient

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,4 +1,6 @@
 .home-banner {
+  // prevent horizontal scrollign
+  overflow: hidden;
   position: relative;
   height: 100vh;
   // next line was from: https://stackoverflow.com/a/23935891/6728463


### PR DESCRIPTION
Fixes the issue of being able to scroll right after the gradietn.
<img width="205" alt="Screen Shot 2022-01-30 at 23 55 47" src="https://user-images.githubusercontent.com/18746187/151704896-fec8266c-9c7e-4c55-b4a0-de0614e87f3c.png">
