### PR TITLE
Prevents refresh on update

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -30,7 +30,11 @@ class BookingsController < ApplicationController
 
     authorize @booking
 
-    redirect_to kondo_path(@kondo)
+    # prevent refreshing the page from updating the booking status
+    respond_to do |format|
+    format.js
+    format.html
+    end
   end
 
   private

--- a/app/views/kondos/show.html.erb
+++ b/app/views/kondos/show.html.erb
@@ -53,7 +53,7 @@
           <div class="col-4 bg-white p-4 m-2">
             <p>Renter: <%= User.find(booking.user_id).first_name %></p>
             <p>Booked Date: <%= booking.booked_date %></p>
-            <%= simple_form_for ([@kondo, booking])  do |f| %>
+            <%= simple_form_for ([@kondo, booking]) do |f| %>
               <div class="d-flex align-items-center">
                 <%= f.input :status, :collection => ['waiting','confirmed','declined','completed'], label: false %>
                 <%= f.submit "Update Status", class: "btn btn-success" %>


### PR DESCRIPTION
Can prevent refresh on update BUT, I don't think the info is being passed. When changing the confirmation status, the database does a rollback and it seems to be rendering without the content.

![image](https://user-images.githubusercontent.com/67456282/151797132-5fdee34d-ac84-4987-a806-2818fedb5537.png)
