### PR TITLE
Book only once

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -8,7 +8,7 @@ class Booking < ApplicationRecord
   validate :booked_date_is_a_date
   validate :booked_date_three_days_prior
   validate :booked_date_too_far
-  validates :address, uniqueness: { scope: [:user_id, :kondo_id], message: "You already booked a kondo for this place" }
+  validates :booked_date, uniqueness: { scope: [:user_id, :kondo_id], message: "You already booked this kondo on that day" }
 
   def booked_status_color
     if self.completed? then "#5454E8"

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -8,6 +8,7 @@ class Booking < ApplicationRecord
   validate :booked_date_is_a_date
   validate :booked_date_three_days_prior
   validate :booked_date_too_far
+  validates :address, uniqueness: { scope: [:user_id, :kondo_id], message: "You already booked a kondo for this place" }
 
   def booked_status_color
     if self.completed? then "#5454E8"


### PR DESCRIPTION
I added some validation in Booking model so that a user can only book a kondo once for a given date.

Maybe we could allow the user to book the same kondo on the same day, but for two different places (for example his office and his house?) But we can think about that later once addresses will be implemented in the bookings#new form :)

I reseeded as well and there were no issues, it looks like @carlnoval's booking creation loop is working wonders :D

![Screen Shot 2022-02-02 at 23 16 36](https://user-images.githubusercontent.com/68413600/152171251-19254829-d0a8-4df2-a945-5bd763e33373.png)
